### PR TITLE
A2D no longer resets board

### DIFF
--- a/Firmware/A2D.c
+++ b/Firmware/A2D.c
@@ -50,7 +50,6 @@ struct A2D_Channel_Attributes
 	int value;														//The most current averaged value, includes resolution increase if used
 	int (*formatFunction)(int);										//Used to specify a function that handles the formating of the averaged value
 	unsigned long sumOfSamples;										//Sum of all the A2D samples before it undergoes DSP/Averaging
-	int autoConversion;												//0 means auto-convert, 1 means external trigger convert
 } A2D_Channel[NUMBER_OF_CHANNELS];
 
 /*************Function  Prototypes***************/
@@ -124,8 +123,7 @@ void A2D_Routine(uint32_t time_mS)
 
 void Trigger_A2D_Scan(void)
 {
-	#warning "Code not implemented"
-//	START_SCAN;
+	START_SCAN;
 	return;
 }
 
@@ -145,6 +143,19 @@ void __attribute__((__interrupt__, auto_psv)) _ADC1Interrupt(void)
 
 void A2D_Initialize(void)
 {
+	int channel;
+	
+	for(channel = 0; channel < NUMBER_OF_CHANNELS; ++channel)
+	{
+		A2D_Channel[channel].bitsOfResolutionIncrease = RESOLUTION_10_BIT;
+		A2D_Channel[channel].samplesRequired = ~0;
+		A2D_Channel[channel].valueForDSP = ~0;
+		A2D_Channel[channel].samplesTaken = 0;
+		A2D_Channel[channel].value = 0;
+		A2D_Channel[channel].formatFunction = (void*)0;
+		A2D_Channel[channel].sumOfSamples = 0;
+	}
+
 	//AD1 Interrupt
 	IFS0bits.AD1IF = 0;				//0 = Interrupt request has not occurred
 	IEC0bits.AD1IE = 1;				//1 = Interrupt request is enabled

--- a/Firmware/A2D.h
+++ b/Firmware/A2D.h
@@ -83,8 +83,6 @@ enum A2D_PIN_DEFINITIONS
 #define A2D_LIBRARY
 
 /*************   Magic  Numbers   ***************/
-#define AUTO_CONVERSION			0
-
 /*************    Enumeration     ***************/
 enum RESOLUTION
 {


### PR DESCRIPTION
The A2D code was dividing by zero because of uninitialized channel 4 and
5 (if it somehow got passed 4)
-Added intialization code for all channels, this will be modified when a
channel is setup
-Configured the code to trigger samples again
-Removed the vestigal auto conversion variables and definitions
NOTE: The sample time is still set at max and needs to be revisited